### PR TITLE
refactor: グループ一覧取得をopenapi-react-queryに移行

### DIFF
--- a/frontend/src/features/group/lib/index.ts
+++ b/frontend/src/features/group/lib/index.ts
@@ -1,0 +1,4 @@
+export * from './use-group-detail'
+export * from './use-joined-groups'
+export * from './query-keys'
+export * from './invalidation'

--- a/frontend/src/features/group/lib/invalidation.ts
+++ b/frontend/src/features/group/lib/invalidation.ts
@@ -1,0 +1,8 @@
+import { queryClient } from '@/shared/api/react-query'
+import { queryKeys } from './query-keys'
+
+export const invalidateGroups = {
+  all: () => queryClient.invalidateQueries({ queryKey: queryKeys.groups.all }),
+  lists: () =>
+    queryClient.invalidateQueries({ queryKey: queryKeys.groups.lists() }),
+}

--- a/frontend/src/features/group/lib/query-keys.ts
+++ b/frontend/src/features/group/lib/query-keys.ts
@@ -1,0 +1,6 @@
+export const queryKeys = {
+  groups: {
+    all: ['groups'] as const,
+    lists: () => [...queryKeys.groups.all, 'list'] as const,
+  },
+} as const

--- a/frontend/src/features/group/lib/use-group-detail.ts
+++ b/frontend/src/features/group/lib/use-group-detail.ts
@@ -1,57 +1,26 @@
-import { useState, useEffect } from 'react'
-import { client } from '@/shared/api'
+import { api } from '@/shared/api'
 import { GroupInfo } from '../model'
 
-interface UseGroupDetailResult {
-  data: GroupInfo | null
+type UseGroupDetailResult = {
+  data: GroupInfo | undefined
   isLoading: boolean
-  error: string | null
+  error: string | undefined
   refetch: () => Promise<void>
 }
 
 export const useGroupDetail = (groupId: string): UseGroupDetailResult => {
-  const [data, setData] = useState<GroupInfo | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const fetchGroupDetail = async () => {
-    setIsLoading(true)
-    setError(null)
-
-    try {
-      const response = await client.GET('/groups/{id}', {
-        params: {
-          path: { id: groupId },
-        },
-      })
-
-      if (response.error) {
-        setError('グループ詳細の取得に失敗しました')
-      } else {
-        setData(response.data)
-      }
-    } catch (err) {
-      setError('グループ詳細の取得に失敗しました')
-      console.error('useGroupDetail error:', err)
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  const refetch = async () => {
-    await fetchGroupDetail()
-  }
-
-  useEffect(() => {
-    if (groupId) {
-      fetchGroupDetail()
-    }
-  }, [groupId])
+  const query = api.useQuery('get', '/groups/{id}', {
+    params: {
+      path: { id: groupId },
+    },
+  })
 
   return {
-    data,
-    isLoading,
-    error,
-    refetch,
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error?.message,
+    refetch: async () => {
+      await query.refetch()
+    },
   }
 }

--- a/frontend/src/screens/group/ui/list.tsx
+++ b/frontend/src/screens/group/ui/list.tsx
@@ -1,5 +1,4 @@
-import { GroupList } from '@/features/group'
-import { useJoinedGroups } from '@/features/group/lib/use-joined-groups'
+import { GroupList, useJoinedGroups } from '@/features/group'
 import { View, StyleSheet, ActivityIndicator, Text } from 'react-native'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { GroupStackParamList } from './stack-navigator'


### PR DESCRIPTION
## 変更内容
従来のfetch実装からopenapi-react-queryのuseQueryに移行し、データフェッチ機能を統一

## 実装詳細
- [x] openapi-react-queryとReact Queryの導入
- [x] グループ一覧取得をopenapi-react-queryに移行  
- [x] グループ詳細取得をopenapi-react-queryに移行
- [x] frontend CI設定を追加

## テスト
- [x] 手動テスト実行済み
- [x] 型チェック通過

## チェックリスト
- [x] コードレビュー準備完了
- [x] 破壊的変更なし
- [x] 関連Issue: なし

## 備考
この変更により、データフェッチ機能が統一され、コードの保守性と開発効率が向上します。
React Queryのキャッシュ機能やリアルタイム更新機能も活用できるようになりました。